### PR TITLE
chore: fix issue

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -30,7 +30,7 @@ class CounterView extends ContraView<CounterController> {
   CounterView({super.key}) : super(CounterController());
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Contra Example'),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -21,7 +21,32 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      home: CounterView(),
+      home: const CounterViewWihtBuilder(),
+    );
+  }
+}
+
+class CounterViewWihtBuilder extends StatelessWidget {
+  const CounterViewWihtBuilder({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ContraViewBuilder(
+      controllerBuilder: () => CounterController(),
+      builder: (context, controller) {
+        return Scaffold(
+          appBar: AppBar(
+            title: const Text('Contra Example'),
+          ),
+          body: Center(
+            child: Text("${controller.counter}"),
+          ),
+          floatingActionButton: FloatingActionButton(
+            onPressed: () => controller.increment(),
+            child: const Icon(Icons.add),
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/contra.dart
+++ b/lib/contra.dart
@@ -2,5 +2,6 @@ library contra;
 
 export 'src/contra_view.dart';
 export 'src/contra_controller.dart';
+export 'src/contra_builder.dart';
 
 

--- a/lib/contra.dart
+++ b/lib/contra.dart
@@ -1,5 +1,6 @@
+library contra;
+
 export 'src/contra_view.dart';
 export 'src/contra_controller.dart';
-
 
 

--- a/lib/src/contra_builder.dart
+++ b/lib/src/contra_builder.dart
@@ -1,0 +1,58 @@
+import 'package:contra/contra.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class ContraViewBuilder<T extends ContraController> extends ConsumerStatefulWidget {
+  const ContraViewBuilder({
+    super.key,
+    required this.builder,
+    required this.controllerBuilder,
+    this.onViewReady,
+    this.onDispose,
+  });
+
+  /// Function will be called when the [ContraController] is ready to be used.
+  final Function(T controller)? onViewReady;
+
+  /// Function will be called when the widget element has been dispose
+  final Function(T controller)? onDispose;
+
+  /// [ContraView] controller, we can use this to progate things later, such us intializing.
+  final T Function() controllerBuilder;
+
+  final Widget Function(BuildContext context, T controller) builder;
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() => _ContraViewControllerState<T>();
+}
+
+class _ContraViewControllerState<T extends ContraController>
+    extends ConsumerState<ContraViewBuilder<T>> {
+  late T _controller;
+
+  /// Initialize the controller
+  void initializeController(WidgetRef ref) {
+    _controller = widget.controllerBuilder();
+    _controller.ref = ref;
+
+    /// Supply the controller to the view
+    widget.onViewReady?.call(_controller);
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    initializeController(ref);
+  }
+
+  @override
+  void dispose() {
+    widget.onDispose?.call(_controller);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.builder(context, _controller);
+  }
+}

--- a/lib/src/contra_view.dart
+++ b/lib/src/contra_view.dart
@@ -23,5 +23,5 @@ abstract class ContraView<C extends ContraController> extends ContraViewControll
   /// Function will be called when he model from [controller] changes.
   @override
   @protected
-  Widget build(BuildContext context, WidgetRef ref);
+  Widget build(BuildContext context);
 }

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -5,7 +5,7 @@ abstract class ContraViewController extends ConsumerStatefulWidget {
   const ContraViewController({super.key});
 
   @protected
-  Widget build(BuildContext contex, WidgetRef ref);
+  Widget build(BuildContext contex);
 
   @protected
   void supplyRef(WidgetRef value);
@@ -18,6 +18,6 @@ class _ContraViewControllerState extends ConsumerState<ContraViewController> {
   @override
   Widget build(BuildContext context) {
     (widget).supplyRef(ref);
-    return (widget).build(context, ref);
+    return (widget).build(context);
   }
 }

--- a/lib/src/src.dart
+++ b/lib/src/src.dart
@@ -1,2 +1,3 @@
 export 'contra_controller.dart';
 export 'contra_view.dart';
+export 'contra_builder.dart';


### PR DESCRIPTION
## **User description**
Updated Configuration


___

## **Type**
enhancement


___

## **Description**
- Introduced a library declaration for Contra, enhancing project structure.
- Simplified the `build` method across various classes (`CounterView`, `ContraView`, and `ContraViewController`) by removing the unused `WidgetRef ref` parameter. This change streamlines the method signatures and aligns with a cleaner architecture.
- In `ContraViewController`, removed the `supplyRef` call and updated the `build` method to reflect the removal of the `WidgetRef ref` parameter.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.dart</strong><dd><code>Simplify `build` Method in `CounterView`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

example/lib/main.dart
<li>Removed <code>WidgetRef ref</code> parameter from the <code>build</code> method in <code>CounterView</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/bushaHQ/Contra/pull/2/files#diff-72fd825ad17ce7800a2078e06f0dff1e12836ee59760465e78d9a5d222cebd15">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>contra.dart</strong><dd><code>Declare Contra Library</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/contra.dart
- Added `library contra;` declaration at the top of the file.



</details>
    

  </td>
  <td><a href="https://github.com/bushaHQ/Contra/pull/2/files#diff-ce4ba2ea59285640b4ee5f0aedfc70fc6a3583ad26767666109e907cd41a86ad">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>contra_view.dart</strong><dd><code>Simplify `build` Method in `ContraView`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/src/contra_view.dart
<li>Removed <code>WidgetRef ref</code> parameter from the <code>build</code> method in <code>ContraView</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/bushaHQ/Contra/pull/2/files#diff-98b57b9c9929d14edd7d67d0f2080c5e60b82772b70c2040a63bfe52e0cf6440">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>controller.dart</strong><dd><code>Refactor `ContraViewController` Build Method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/src/controller.dart
<li>Removed <code>WidgetRef ref</code> parameter from the <code>build</code> method in <br><code>ContraViewController</code>.<br> <li> Removed the call to <code>supplyRef</code> and updated the <code>build</code> method to not pass <br><code>ref</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/bushaHQ/Contra/pull/2/files#diff-cb008868dcbfd2e9a23ec7ead01a9af610f00b3ef8040885bd4ad8613dc401d2">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

